### PR TITLE
Add igly.ai image editor

### DIFF
--- a/ai_tools_cpu/ai_tools.md
+++ b/ai_tools_cpu/ai_tools.md
@@ -121,6 +121,7 @@
 | https://stabledifffusion.com/stable-diffusion-3-medium            | stable-diffusion-3-medium            |
 | https://huggingface.co/spaces/sczhou/CodeFormer                   | CodeFormer image Resizer             |
 | https://imgupscaler.com/                                          | image upscaler                       |
+| https://igly.ai                                                   | AI image editor for background removal, inpainting, upscaling, and generative fill |
 
 
 ### voice


### PR DESCRIPTION
Adds igly.ai to the AI image tools table.\n\nigly.ai supports background removal, inpainting, upscaling, and generative fill workflows.\n\nDemo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is